### PR TITLE
Add MetaTitle to scaffold_cms_fields_settings ignoreFields

### DIFF
--- a/src/MetaTitleExtension.php
+++ b/src/MetaTitleExtension.php
@@ -23,6 +23,10 @@ class MetaTitleExtension extends Extension
         'MetaTitle' => 'Varchar(255)'
     ];
 
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => ['MetaTitle'],
+    ];
+
     private static string $title_format = '$MetaTitle &raquo; $SiteConfig.Title';
 
     public function updateCMSFields(FieldList $fields)


### PR DESCRIPTION
## Summary
- Adds `scaffold_cms_fields_settings` config to exclude `MetaTitle` from automatic CMS field scaffolding
- The field is already added manually via `updateCMSFields`, so scaffolding it bypasses the RedirectorPage/VirtualPage exclusion and causes the field to appear where it shouldn't
- This is a Silverstripe 6 issue where extensions' `$db` fields are scaffolded into the CMS by default